### PR TITLE
Update ng-pouchdb-collection.js

### DIFF
--- a/www/js/ng-pouchdb-collection.js
+++ b/www/js/ng-pouchdb-collection.js
@@ -43,6 +43,7 @@ angular.module('pouchdb')
         indexes[id] = undefined;
 
         console.log('removed: ', id);
+        return index;
       }
 
       function updateChild (index, item) {
@@ -80,8 +81,7 @@ angular.module('pouchdb')
             }
           });
         } else { //DELETE
-          removeChild(change.id);
-          updateIndexes(indexes[change.id]);
+          updateIndexes(removeChild(change.id));
         }
       }});
 


### PR DESCRIPTION
Removed index was undefined (no longer exists after remove) and updateindex did not work properly. Solution: pass explicity the removed index to the updateIndex.
